### PR TITLE
Fix RUST_SRC_PATH and pager executable

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -67,7 +67,7 @@ pub fn generate_stdlib_docs() -> Result<()> {
     let rust_src_dir = env::var("RUST_SRC_PATH")
         .chain_err(|| format!("RUST_SRC_PATH was not set when trying to generate stdlib docs."))?;
 
-    let stdlib_paths = read_dir(format!("{}/src", rust_src_dir))
+    let stdlib_paths = read_dir(rust_src_dir)
         .chain_err(|| "Couldn't read rust source path")?;
     let mut paths = Vec::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,15 @@ fn page_search_query(query: &str) -> Result<()> {
         })
         .collect();
 
-    Pager::new().with_executable("more -r").setup();
+    // Linux and BSD systems doesn't support "-r" option but macOS supports
+    // For linux `less` shows better results (with control chars)
+    #[cfg(target_os = "macos")]
+    let executable = "more -r";
+
+    #[cfg(not(target_os = "macos"))]
+    let executable = "less";
+
+    Pager::new().with_executable(executable).setup();
 
     for result in formatted {
         println!("{}", result);


### PR DESCRIPTION
Other tools agrees on RUST_SRC_PATH already contains last /src part to
be set in the ENV variable. No need to append /src.

Using `more` for pager program is problematic on non macOS systems. Since neither bsd nor linux version of `more` doesn't support `-r` option, I tried `less` program and get correct results (correct according to your screenshots). 